### PR TITLE
Changing map center to match given center point

### DIFF
--- a/wigleQuery.py
+++ b/wigleQuery.py
@@ -42,7 +42,7 @@ clrs = ["red", "yellow", "blue", "orange", "purple", "green", "black", "white", 
 #setup map in AoI
 lat = 39.7392
 lon = -104.9903
-gmap = gmplot.GoogleMapPlotter(lat, lon, 5)
+gmap = gmplot.GoogleMapPlotter(lati, long, 14)
 gmap.apikey = googleMapAPI
 
 lat_list = [] 


### PR DESCRIPTION
Adjusted the code to use the provided lat/lon to set the map's center point, zoom level 14; current behavior starts the HTML page at a zoom level 5 above the continental US and requires extensive panning to get to the actual query.